### PR TITLE
Fix spelling of Lenovo Miix 630's name in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This image is ready to be flashed onto an SD card to boot any one of the 3 devic
 
  * Asus NovaGo TP370QL
  * HP Envy x2
- * Lenovo Mixx 630
+ * Lenovo Miix 630
 
 **IMPORTANT:** This image must be flashed using the [Flash Tool](https://github.com/aarch64-laptops/prebuilt/blob/master/flash-prebuilt.sh) provided by this repo.
 
@@ -31,7 +31,7 @@ $ sudo mount /dev/<SD_CARD>2 <SDCARD_MOUNT_POINT>
 $ ln -s /boot/<LAPTOP_DTB> <SDCARD_MOUNT_POINT>/boot/laptop.dtb
 ```
 
-Where <LAPTOP_DTB> is either `laptop-asus-tp370ql.dtb` for the Asus NovaGo TP370QL or `laptop-hp-envy-x2.dtb` for HP Envy x2 and Lenovo Mixx 630
+Where <LAPTOP_DTB> is either `laptop-asus-tp370ql.dtb` for the Asus NovaGo TP370QL or `laptop-hp-envy-x2.dtb` for HP Envy x2 and Lenovo Miix 630
 
 **Note:** Currently there are no known differences between the later 2 devices, so they use the same DTB.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 ## AArch64 Laptop Prebuilt Images
 
-These are the latest prebuilt images for your consumption.  There are currently 2 images available:
+### TODO
+
+The current [Jobs List](#Jobs-list) can be seen below.
+
+### Images
+
+This repos offers the latest prebuilt images for your consumption.  There are currently 2 images available:
 
  * Complete prebuilt (configured) image
    * This image is **almost** (see below) ready for booting
+
  * Clean (not configured) Ubuntu Bionic image
    * This image is designed for the [Image Builder](https://github.com/aarch64-laptops/build) to consume
 
-### Complete (configured) prebuilt image
+#### Complete prebuilt (configured) image
 
 This image is ready to be flashed onto an SD card to boot any one of the 3 devices currently supported by this project:
 
@@ -68,3 +75,7 @@ When used, it provides the following benefits:
 2. Saves a great deal of time (2 hours) in the Ubuntu installer
 
 **Note:** This image is not bootable on its own.
+
+## Jobs List
+
+TODO


### PR DESCRIPTION
There's two "i"s in "Miix".